### PR TITLE
Some minor fixes to BufferedStreams

### DIFF
--- a/lib/buffered-stream.js
+++ b/lib/buffered-stream.js
@@ -34,9 +34,23 @@ var BufferedStream = module.exports = function (limit) {
   this.chunks = [];
   this.writable = true;
   this.readable = true;
+  this._buffer = true;
 };
 
 util.inherits(BufferedStream, stream.Stream);
+
+Object.defineProperty(BufferedStream.prototype, 'buffer', {
+  get: function () {
+    return this._buffer;
+  },
+  set: function (value) {
+    if (!value) {
+      delete this.chunks
+    }
+
+    this._buffer = value;
+  }
+});
 
 BufferedStream.prototype.pipe = function () {
   var self = this;
@@ -91,7 +105,10 @@ BufferedStream.prototype.write = function (chunk) {
 BufferedStream.prototype.end = function () {
   this.readable = false;
   this.ended = true;
-  this.emit('end');
+
+  if (!this.chunks) {
+    this.emit('end');
+  }
 };
 
 BufferedStream.prototype.close = function () {

--- a/test/fixtures/pipe-write-test.txt
+++ b/test/fixtures/pipe-write-test.txt
@@ -1,1 +1,1 @@
-hello world
+hello worldhello world

--- a/test/streaming-test.js
+++ b/test/streaming-test.js
@@ -14,11 +14,15 @@ vows.describe('union/streaming').addBatch({
         union.createServer({
           before: [
             function (req, res, next) {
+              var chunks = '';
+
+              req.buffer = false;
+              req.on('data', function (chunk) {
+                chunks += chunk;
+              });
+
               req.on('end', function () {
-                req.pipe(res);
-                process.nextTick(function () {
-                  self.callback(null, chunks);
-                })
+                self.callback(null, chunks);
               });
             }
           ]


### PR DESCRIPTION
@mmalecki So the problem here was two fold. The `req` objects that come in to middleware handlers are buffered by default. So no `data` or `end` events will be emitted. I added a feature to our `BufferedStream` implementation which can disable buffering: 

``` js
  req.buffer = false;
```

But this feature should be used with **extreme caution**
