### PR TITLE
Fixed typo in the README file

### DIFF
--- a/README.md
+++ b/README.md
@@ -247,7 +247,7 @@ Example
 var hs = union.HttpStream();
 ```
 
-## HttpStream Instance Memebers
+## HttpStream Instance Members
 
 ### url
 The url from the request.


### PR DESCRIPTION
Changed "HttpStream Instance Memebers" to "HttpStream Instance Members"... 
