### PR TITLE
Trivial fix setting req.originalUrl to support connect>2.3.5

### DIFF
--- a/lib/http-stream.js
+++ b/lib/http-stream.js
@@ -38,7 +38,7 @@ HttpStream.prototype.pipeState = function (source) {
   this.method = source.method;
 
   if (source.url) {
-    this.url = source.url;
+    this.url = this.originalUrl = source.url;
   }
 
   if (source.query) {

--- a/lib/request-stream.js
+++ b/lib/request-stream.js
@@ -30,7 +30,7 @@ util.inherits(RequestStream, HttpStream);
 // Remark: Is there anything else we wish to pipe?
 //
 RequestStream.prototype.pipeRequest = function (source) {
-  this.url = source.url;
+  this.url = this.originalUrl = source.url;
   this.method = source.method;
   this.httpVersion = source.httpVersion;
   this.setEncoding = source.setEncoding;


### PR DESCRIPTION
I've built @psunkara test suite (here: https://github.com/framp/connect-union) for connect and union (following what he did with the previous version) and fixed the trivial bug of originalUrl.

It looks like both req.url and req.originalUrl are being used.

There are still 7 errors according to the test, but I'm not sure if they're bugs specific to union or simply differences between flatiron and connect (as I'm not familiar with the codebase)

1) connect.cookieSession() should reset on invalid parse:
     TypeError: Cannot read property 'should' of undefined
(Here the test expect a variable set to null instead of undefined)
  2) connect.session() req.session .cookie when the pathname does not match cookie.path should not set-cookie:
     TypeError: Cannot set property 'foo' of undefined
  3) connect.static() when a trailing backslash is given should 500:
     Error: Parse Error
  4) connect.static() when mounted should redirect relative to the originalUrl:
     TypeError: Property '0' of object /static is not a function
  5) connect.static() on ENAMETOOLONG should next():
     Error: timeout of 600ms exceeded
  6) connect.static() on ENAMETOOLONG should next():
     Error: timeout of 600ms exceeded
