### PR TITLE
Sessions are not saved when using Connect.session() middleware.

### DIFF
--- a/lib/response-stream.js
+++ b/lib/response-stream.js
@@ -162,17 +162,24 @@ ResponseStream.prototype.write = function (data) {
 
 ResponseStream.prototype.redirect = function(path, status) {
   var url = '';
-  
+
   if(~path.indexOf('://')) {
     url = path;
   } else {
     url += this.req.connection.encrypted ? 'https://' : 'http://';
     url += this.req.headers.host;
-    url += (path[0] === '/') ? path : '/' + path; 
+    url += (path[0] === '/') ? path : '/' + path;
   }
- 
+
   this.res.writeHead(status || 302, {
     'Location': url
   });
-  this.res.end();
+
+  // Prefer this.end over this.res.end so that connect.session will save.
+  if ((typeof this.end)==='function') {
+    this.end();
+  }
+  else {
+    this.res.end();
+  }
 };


### PR DESCRIPTION
I am working on getting FlatIron to play nicely with Passport.js with https://github.com/travist/flatiron-passport.

I noticed that the session saving fails with OAuth because https://github.com/senchalabs/connect/blob/master/lib/middleware/session.js#L274 tries to inject itself before the end method is called.  However this is attached to the `this` pointer of the request object and not `this.res`.

This can all be fixed if we just check to see if the `end` method is attached to `this`, and call it instead if it is... If not, then fallback to current behavior.
