### PR TITLE
ResponseStream.prototype.redirect needs to call this.end() instead of this.response.end()

### DIFF
--- a/lib/response-stream.js
+++ b/lib/response-stream.js
@@ -162,15 +162,15 @@ ResponseStream.prototype.write = function (data) {
 
 ResponseStream.prototype.redirect = function(path, status) {
   var url = '';
-  
+
   if(~path.indexOf('://')) {
     url = path;
   } else {
     url += this.req.connection.encrypted ? 'https://' : 'http://';
     url += this.req.headers.host;
-    url += (path[0] === '/') ? path : '/' + path; 
+    url += (path[0] === '/') ? path : '/' + path;
   }
- 
+
   this.response.writeHead(status || 302, { 'Location': url });
-  this.response.end();
+  this.end();
 };


### PR DESCRIPTION
I am testing the latest version of union with flatiron-passport which does OAuth redirects.  What happens is the session is not getting stored on redirect which causes the OAuth to fail after the redirect occurs.  What cases this failure is that none of the `end` hooks are triggered when a redirect occurs.  This can easily be fixed if we use `this.end()` in the ResponseStream instead of using `this.response.end()` since that bypasses any registered `end` callbacks. 

I stepped through this and it still calls `this.response.end()` after these callbacks have been triggered which leads me to believe that this fix is good, but would love to hear your opinion on that.

Thanks,

Travis.
