### PR TITLE
emit end event if ended when manualy triggering unbuffer

### DIFF
--- a/examples/simple/simple.js
+++ b/examples/simple/simple.js
@@ -45,6 +45,16 @@ router.get('/custom_redirect', function() {
   this.res.redirect('/foo', 301);
 });
 
+router.get('/async', function () {
+  var self = this;
+  process.nextTick(function () {
+    self.req.on('end', function () {
+      self.res.end();
+    })
+    self.req.buffer = false;
+  });
+});
+
 server.listen(9090);
 console.log('union with director running on 9090');
 

--- a/lib/buffered-stream.js
+++ b/lib/buffered-stream.js
@@ -47,6 +47,7 @@ Object.defineProperty(BufferedStream.prototype, 'buffer', {
     if (!value && this.chunks) {
       var self = this;
       this.chunks.forEach(function (c) { self.emit('data', c) });
+      if (this.ended) this.emit('end');
       this.size = 0;
       delete this.chunks;
     }

--- a/test/simple-test.js
+++ b/test/simple-test.js
@@ -72,6 +72,18 @@ vows.describe('union/simple').addBatch({
           assert.equal(res.statusCode, 301);
           assert.equal(res.headers.location, "http://localhost:9090/foo");
         }
+      },
+      "a GET request to `/async`": {
+        topic: function() {
+          request.get({
+            url: 'http://localhost:9090/async',
+            timeout: 500
+          }, this.callback);
+        },
+        "it should not timeout": function (err, res, body) {
+          assert.ifError(err);
+          assert.equal(res.statusCode, 200);
+        }
       }
     }
   }


### PR DESCRIPTION
With this change it is possible to use `union` together with an asynchronous middleware and `nodejitsu/node-http-proxy`.
