### PR TITLE
[fix] check _header for being set

### DIFF
--- a/lib/response-stream.js
+++ b/lib/response-stream.js
@@ -58,8 +58,10 @@ var ResponseStream = module.exports = function (options) {
       if (!self._emittedHeader) {
         self._emittedHeader = true;
         self.headerSent = true;
+        self._header = true;
         self.emit('header');
       }
+
       return self._renderHeaders.call(self.response);
     };
   }


### PR DESCRIPTION
Collection of patches against the newer expressjs middleware collection/connect 3.0 (for reference see https://github.com/senchalabs/connect#connect-30)
- set `_header` in response stream, _TODO other header flags might not be used anymore_
