### PR TITLE
ability to pass secureProtocol and secureOptions to https server

### DIFF
--- a/lib/core.js
+++ b/lib/core.js
@@ -74,6 +74,14 @@ core.createServer = function (options) {
       cert: fs.readFileSync(serverOptions.cert)
     };
 
+    if(serverOptions.secureProtocol){
+      credentials['secureProtocol'] = serverOptions.secureProtocol;
+    }
+
+    if(serverOptions.secureOptions){
+      credentials['secureOptions'] = serverOptions.secureOptions;
+    }
+
     if (serverOptions.ca) {
       serverOptions.ca = !Array.isArray(serverOptions.ca)
         ? [serverOptions.ca]


### PR DESCRIPTION
Want to pass secureProtocol and secureOptions options to https server.  Can be useful for a cases like this:
https://gist.github.com/3rd-Eden/715522f6950044da45d8