### PR TITLE
Upgrade qs dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "url": "http://github.com/flatiron/union.git"
   },
   "dependencies": {
-    "qs": "~2.3.3"
+    "qs": "^6.4.0"
   },
   "devDependencies": {
     "ecstatic": "0.5.x",


### PR DESCRIPTION
Previously required version contained a security vulnerability. See #59 and https://snyk.io/vuln/npm:qs:20170213