### PR TITLE
support for Node.js 12

### DIFF
--- a/lib/response-stream.js
+++ b/lib/response-stream.js
@@ -47,7 +47,15 @@ var ResponseStream = module.exports = function (options) {
   });
 
   if (this.response) {
-    this._headers = this.response.getHeaders() || {};
+
+    try {
+      this._headers = this.response.getHeaders() || {};
+    } catch (err) {
+      this._headers = this.response._headers = this.response._headers || {};
+
+      // Patch to node core
+      this.response._headerNames = this.response._headerNames || {};  
+    }
 
     //
     // Proxy to emit "header" event

--- a/lib/response-stream.js
+++ b/lib/response-stream.js
@@ -47,10 +47,7 @@ var ResponseStream = module.exports = function (options) {
   });
 
   if (this.response) {
-    this._headers = this.response._headers = this.response._headers || {};
-
-    // Patch to node core
-    this.response._headerNames = this.response._headerNames || {};
+    this._headers = this.response.getHeaders() || {};
 
     //
     // Proxy to emit "header" event


### PR DESCRIPTION
```
[DEP0066] DeprecationWarning: OutgoingMessage.prototype._headers is deprecated
[DEP0066] DeprecationWarning: OutgoingMessage.prototype._headerNames is deprecated
```

https://nodejs.org/api/deprecations.html#deprecations_dep0066_outgoingmessage_prototype_headers_outgoingmessage_prototype_headernames