### PR TITLE
PK Passphrase support

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,6 +179,7 @@ An example of the `https` or `spdy` option.
 {
   cert: 'path/to/cert.pem',
   key: 'path/to/key.pem',
+  passphrase: '<secret>',
   ca: 'path/to/ca.pem'
 }
 ```

--- a/lib/core.js
+++ b/lib/core.js
@@ -74,6 +74,10 @@ core.createServer = function (options) {
       cert: fs.readFileSync(serverOptions.cert)
     };
 
+    if (serverOptions.passphrase) {
+      credentials.passphrase = serverOptions.passphrase;
+    }
+
     if (serverOptions.ca) {
       serverOptions.ca = !Array.isArray(serverOptions.ca)
         ? [serverOptions.ca]


### PR DESCRIPTION
Closes #58 

Added the passphrase to the credential options. This makes it possible to use encrypted private keys, looking like this:
```
-----BEGIN ENCRYPTED PRIVATE KEY-----
abc123.............
-----END ENCRYPTED PRIVATE KEY-----
```

- [x] tested with HTTPS, self-signed cert