### PR TITLE
Add license field to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "maintainers": [
     "dscape <nuno@nodejitsu.com>"
   ],
+  "license": "MIT",
   "repository": {
     "type": "git",
     "url": "http://github.com/flatiron/union.git"


### PR DESCRIPTION
This package misses license information in the [npm registry](https://www.npmjs.com/package/union).

![screenshot_2022-04-26_07-48-33_588616491](https://user-images.githubusercontent.com/3976183/165230531-91230872-9b53-4b26-9460-6a2752cc7bbc.png)

By adding the license field to the `package.json` file, other tools such as [license-ls](https://www.npmjs.com/package/license-ls) can pick-up the license information. This is important to be done right, otherwise this package will lead a false positive in automated dependency scanners as they often are used in companies.

