### PR TITLE
Update qs dependency and bump version to 0.7.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "union",
   "description": "A hybrid buffered / streaming middleware kernel backwards compatible with connect.",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "author": "Charlie Robbins <charlie.robbins@gmail.com>",
   "maintainers": [
     "dscape <nuno@nodejitsu.com>"
@@ -11,7 +11,7 @@
     "url": "http://github.com/flatiron/union.git"
   },
   "dependencies": {
-    "qs": "^6.4.0"
+    "qs": "^6.14.1"
   },
   "devDependencies": {
     "ecstatic": "0.5.x",


### PR DESCRIPTION
References: #84 ([Security] Dependency update needed: qs)

Note: on merge, one needs to create a new release/tag